### PR TITLE
Adding basic integral and fraction support

### DIFF
--- a/src/fonts.jl
+++ b/src/fonts.jl
@@ -40,7 +40,7 @@ get_symbol_char(char::Char, command, fontset) = TeXChar(char, fontset.math)
 thickness(fontset) = thickness(fontset.math)
 
 const NewComputerModern = NewCMFontSet(
-    FTFont("assets/fonts/NewCM10-regular.otf"),
-    FTFont("assets/fonts/NewCM10-italic.otf"),
-    FTFont("assets/fonts/NewCMMath-regular.otf")
+    FTFont("assets/fonts/NewCM10-Regular.otf"),
+    FTFont("assets/fonts/NewCM10-Italic.otf"),
+    FTFont("assets/fonts/NewCMMath-Regular.otf")
 )


### PR DESCRIPTION
Hi,

this PR renames the included font files names to match capitalization of the actual files
and adds very basic fraction and integral support.

"Real" latex uses different integral symbols but if I saw correctly, you've already tried to get symbols fonts working 
yourself. I left a `todo` to replace that at some point.
