### PR TITLE
Deal with empty group and strings

### DIFF
--- a/test/layout.jl
+++ b/test/layout.jl
@@ -28,6 +28,9 @@ end
         expr = manual_texexpr((:decorated, 'z', 'b', nothing))
         layout = tex_layout(expr, FontFamily())
         @test layout.elements[3] == Space(0)
+
+        @test length(generate_tex_elements(L"a_b^c")) == 3
+        @test length(generate_tex_elements(L"_b^c")) == 2
     end
 
     @testset "Delimited" begin
@@ -68,6 +71,9 @@ end
         @test length(layout.positions) == 2
         @test length(layout.scales) == 2
         test_same_layout(sublayout, layout.elements[2])
+
+        @test isempty(generate_tex_elements(L"{}"))
+        @test isempty(generate_tex_elements(L""))
     end
 
     @testset "Space" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -74,6 +74,7 @@ end
             raw"{a{b{cd}}}",
             (:group, 'a', (:group, 'b', (:group, 'c', 'd')))
         )
+        test_parse(raw"{}", (:space, 0.0))
 
         @test_throws TeXParseError texparse(raw"{v")
         @test_throws TeXParseError texparse(raw"w}")
@@ -142,7 +143,8 @@ end
     end
 
     @testset "Subscript and superscript" begin
-        @test texparse(raw"a^2_3") == texparse("a_3^2")
+        @test texparse(raw"a^2_3") == texparse(raw"a_3^2")
+        @test texparse(raw"^7_b") == texparse(raw"{}^7_b")
     end
 
     @testset "Symbol" begin


### PR DESCRIPTION
Parse empty string and empty groups as 0-width spaces.

Also allow to start the string with `^` or `_`, by adding an empty group at the beginning in these cases.

Fix #30 