### PR TITLE
Fix ascender and descender for symbol fonts in Computer Modern

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MathTeXEngine"
 uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
 authors = ["Benoît Richard <kolaru@hotmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/engine/fonts.jl
+++ b/src/engine/fonts.jl
@@ -139,5 +139,3 @@ The height of the letter x in the given font family, i.e. the height of the lett
 without neither ascender nor descender.
 """
 xheight(font_family) = xheight(get_font(font_family, :regular))
-
-

--- a/src/engine/texelements.jl
+++ b/src/engine/texelements.jl
@@ -150,9 +150,35 @@ for inkfunc in (:leftinkbound, :rightinkbound, :bottominkbound, :topinkbound)
 end
 
 advance(char::TeXChar) = hadvance(get_extent(char.font, char.char))
-ascender(char::TeXChar) = ascender(char.font)
-descender(char::TeXChar) = descender(char.font)
 xheight(char::TeXChar) = xheight(char.font)
+
+function ascender(char::TeXChar)
+    # Special cases for symbol fonts
+    if char.font.family_name == "cmsy10"
+        regular_font = load_font(_default_fonts[:regular])
+        return max(topinkbound(char), ascender(regular_font))
+    end
+
+    if char.font.family_name == "cmex10"
+        return topinkbound(char)
+    end
+
+    return ascender(char.font)
+end
+
+function descender(char::TeXChar)
+    # Special cases for symbol fonts
+    if char.font.family_name == "cmsy10"
+        regular_font = load_font(_default_fonts[:regular])
+        return min(bottominkbound(char), descender(regular_font))
+    end
+
+    if char.font.family_name == "cmex10"
+        return bottominkbound(char)
+    end
+
+    return descender(char.font)
+end
 
 Base.show(io::IO, tc::TeXChar) =
     print(io, "TeXChar '$(tc.represented_char)' [U+$(uppercase(string(codepoint(tc.char), base=16, pad=4))) in $(tc.font.family_name) - $(tc.font.style_name)]")


### PR DESCRIPTION
Also added markers for the ascender and descender in the debug mode of the prototype.