### PR TITLE
Fix rendering of '/'

### DIFF
--- a/src/engine/computer_modern_data.jl
+++ b/src/engine/computer_modern_data.jl
@@ -67,7 +67,6 @@ _latex_to_computer_modern = Dict(
     raw"\zeta"                     => ("cmmi10", 0xb3),
 
        "\\"                        => ("cmsy10", 0x6e),
-    raw"/"                         => ("cmsy10", 0x36),
 
     raw"!"                         => ("cmr10", 0x21),
     raw"%"                         => ("cmr10", 0x25),


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/JuliaPlots/Makie.jl/issues/1967, by which the `/` character is incorrectly rendered in math.

Here is a small example showcasing the issue:

```julia
using CairoMakie
fig = Figure()
Label(fig[1, 1], L"k^{-5/3}")
```

In the current version, the text is incorrectly rendered as follows:

![test_old](https://user-images.githubusercontent.com/3952024/176956650-9fbe1a6f-a7b1-4976-ae03-1d4f6548b08c.png)

This PR changes the result to:

![test_new](https://user-images.githubusercontent.com/3952024/176956813-3f942029-b326-4a47-882b-b2fd9b6f2c73.png)

The issue seems to come from the `/` character being duplicated in the `_latex_to_computer_modern` dict:

```julia
_latex_to_computer_modern = Dict(
    # ...
    raw"/"                         => ("cmmi10", 0x3d),
    # ...
    raw"/"                         => ("cmsy10", 0x36),
    # ...
)
```

I don't know if this was intentional, but the fact is that Julia ends up keeping the second entry, which seems to have some issues. Concretely, the width of this character seems to be 0 in the font file (if I understand things correctly...) which leads precisely to the wrong rendering above. More explicitly:

```julia
using MathTeXEngine: tex_layout, FontFamily, unravel, LayoutState,
                     horizontal_layout, get_extent, texparse, hadvance

ex = texparse("5/3")
state = LayoutState(FontFamily())
tl = tex_layout(ex, state)

tl.positions
# 3-element Vector{GeometryBasics.Point{2, Float32}}:
#  [0.0, 0.0]  # '5'
#  [0.5, 0.0]  # '/' -> has zero width!
#  [0.5, 0.0]  # '3'

# Alternatively:
char = tl.elements[2]  # '/'
hadvance(char)  # = 0.0f0 (has zero width)

```

By removing this entry, the issue is fixed since the other entry (in the `cmmi10` font) doesn't have this problem.