### PR TITLE
Better support for math fonts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 
 [compat]
 AbstractTrees = "0.3, 0.4"

--- a/prototype/Manifest.toml
+++ b/prototype/Manifest.toml
@@ -68,7 +68,7 @@ version = "1.0.5"
 deps = ["Base64", "Cairo", "Colors", "FFTW", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "SHA"]
 path = "C:\\Users\\kolar\\.julia\\dev\\Makie\\CairoMakie"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.8.11"
+version = "0.8.10"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -545,13 +545,13 @@ version = "2022.0.0+0"
 deps = ["Animations", "Base64", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Distributions", "DocStringExtensions", "FFMPEG", "FileIO", "FixedPointNumbers", "Formatting", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageIO", "IntervalSets", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MakieCore", "Markdown", "Match", "MathTeXEngine", "Observables", "OffsetArrays", "Packing", "PlotUtils", "PolygonOps", "Printf", "Random", "RelocatableFolders", "Serialization", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "UnicodeFun"]
 path = "C:\\Users\\kolar\\.julia\\dev\\Makie"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.17.11"
+version = "0.17.10"
 
 [[deps.MakieCore]]
 deps = ["Observables"]
 path = "C:\\Users\\kolar\\.julia\\dev\\Makie\\MakieCore"
 uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.3.6"
+version = "0.3.5"
 
 [[deps.MappedArrays]]
 git-tree-sha1 = "e8b359ef06ec72e8c030463fe02efe5527ee5142"

--- a/prototype/prototype.jl
+++ b/prototype/prototype.jl
@@ -159,7 +159,7 @@ begin  # Quick test
             \left[ \sqrt{\frac{\Omega-2}{a \langle c^\dagger \rangle b}} \right]^3_3 
             < \int_{0}^{2π} |\sin(\mu x)| dx"
     
-    tex = L"\mathbb{R} \longrightarrow xyz \text{x y z} \mathrm{x y z}"
+    tex = L"\mathcal{A} \mathbb{R} \longrightarrow xyz \text{x y z} \mathrm{x y z}"
 
     makie_tex!(ax, tex, debug=true, size=64)
     fig[3, 1] = Label(fig, tex, tellwidth=false, tellheight=false, textsize=40)

--- a/src/MathTeXEngine.jl
+++ b/src/MathTeXEngine.jl
@@ -6,6 +6,7 @@ using AbstractTrees
 using Automa
 using FreeTypeAbstraction
 using LaTeXStrings
+using UnicodeFun
 
 using Automa.RegExp: @re_str
 using DataStructures: Stack

--- a/src/engine/layout.jl
+++ b/src/engine/layout.jl
@@ -24,7 +24,7 @@ function tex_layout(expr, state)
     shrink = 0.6
 
     try
-        if head in [:char, :delimiter, :digit, :punctuation, :symbol]
+        if isleaf(expr)
             char = args[1]
             texchar = TeXChar(char, state, head)
             return texchar

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -155,6 +155,7 @@ function _end_group!(stack, p, data)
         head, required_n_args = command_builder.args[1:2]
         args = command_builder.args[3:end]
 
+        # Check if the argument gatherer got all the needed arguments
         if required_n_args == length(args)
             pop!(stack)
             command = TeXExpr(head, args)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -106,6 +106,7 @@ end
 
     @testset "LaTeXString input" begin
         @test texparse(raw"\gamma") == texparse(L"\gamma")
+        @test texparse(raw"ℝ") == texparse(raw"\mathbb{R}")
     end
 
     @testset "Overunder" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ import MathTeXEngine: Space, TeXElement
 import MathTeXEngine: _new_computer_modern_fonts, FontFamily, load_font
 import MathTeXEngine: inkheight, inkwidth
 
+include("texexpr.jl")
 include("parser.jl")
 include("fonts.jl")
 include("layout.jl")

--- a/test/texexpr.jl
+++ b/test/texexpr.jl
@@ -1,0 +1,11 @@
+@testset "TeXExpr" begin
+    @testset "leafmap" begin
+        ab = texparse(raw"a + b_a")
+        xx = texparse(raw"x + b_x")
+
+        @test xx == MathTeXEngine.leafmap(ab) do leaf
+            leaf.args[1] == 'a' && return TeXExpr(:char, 'x')
+            return leaf
+        end
+    end
+end


### PR DESCRIPTION
Fix #49

Also improve the tree printing of TeXExpr.