### PR TITLE
Fix \{ and \} parsing

### DIFF
--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -62,6 +62,8 @@ end
 
 command_to_canonical[raw"\frac"] = TeXExpr(:argument_gatherer, [:frac, 2])
 command_to_canonical[raw"\sqrt"] = TeXExpr(:argument_gatherer, [:sqrt, 1])
+command_to_canonical[raw"\{"] = TeXExpr(:delimiter, '{')
+command_to_canonical[raw"\}"] = TeXExpr(:delimiter, '}')
 
 ##
 ## Commands from the commands_data.jl file

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -133,9 +133,14 @@ end
 
 # Set all command as function to play more nicely with Revise.jl
 
-_begin_group!(stack, p, data) = push!(stack, TeXExpr(:group))
+function _begin_group!(stack, p, data)
+    current_head(stack) == :skip_char && return
+    push!(stack, TeXExpr(:group))
+end
 
 function _end_group!(stack, p, data)
+    current_head(stack) == :skip_char && return
+    
     current_head(stack) != :group && throw(
         TeXParseError("Unexpected '}' at position $(p-1)", stack, p, data))
     group = pop!(stack)

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -40,6 +40,10 @@ end
             )
         )
 
+        test_parse(raw"\{", (:delimiter, '{'))
+        test_parse(raw"\}", (:delimiter, '}'))
+
+
         @test_throws TeXParseError texparse(raw"\left( x")
         @test_throws TeXParseError texparse(raw"x \right)")
 


### PR DESCRIPTION
Fix #57