### PR TITLE
implement \overline command

### DIFF
--- a/src/engine/layout.jl
+++ b/src/engine/layout.jl
@@ -137,6 +137,21 @@ function tex_layout(expr, state)
                 ],
                 [1, shrink, shrink]
             )
+        elseif head == :overline
+            content = tex_layout(args[1], state)
+
+            lw = thickness(font_family)
+            y =  topinkbound(content) - lw
+
+            hline = HLine(inkwidth(content) - 0.15, lw)
+
+            return Group(
+                [hline, content],
+                Point2f[
+                    (0.25, y + lw/2 + 0.2),
+                    (0, 0)
+                ]
+            )
         elseif head == :space
             return Space(args[1])
         elseif head == :spaced
@@ -170,21 +185,6 @@ function tex_layout(expr, state)
                     (rightinkbound(sqrt) - lw/2, y + lw/2),
                     (rightinkbound(sqrt), 0),
                     (rightinkbound(content), 0)
-                ]
-            )
-        elseif head == :overline
-            content = tex_layout(args[1], state)
-
-            lw = thickness(font_family)
-            y =  topinkbound(content) - lw
-
-            hline = HLine(inkwidth(content), lw)
-
-            return Group(
-                [hline, content],
-                Point2f[
-                    (0, y + lw/2),
-                    (0, 0)
                 ]
             )
         elseif head == :underover

--- a/src/engine/layout.jl
+++ b/src/engine/layout.jl
@@ -172,7 +172,21 @@ function tex_layout(expr, state)
                     (rightinkbound(content), 0)
                 ]
             )
+        elseif head == :overline
+            content = tex_layout(args[1], state)
 
+            lw = thickness(font_family)
+            y =  topinkbound(content) - lw
+
+            hline = HLine(inkwidth(content), lw)
+
+            return Group(
+                [hline, content],
+                Point2f[
+                    (0, y + lw/2),
+                    (0, 0)
+                ]
+            )
         elseif head == :underover
             core, sub, super = tex_layout.(args, state)
 

--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -62,6 +62,7 @@ end
 
 command_to_canonical[raw"\frac"] = TeXExpr(:argument_gatherer, [:frac, 2])
 command_to_canonical[raw"\sqrt"] = TeXExpr(:argument_gatherer, [:sqrt, 1])
+command_to_canonical[raw"\overline"] = TeXExpr(:argument_gatherer, [:overline, 1])
 command_to_canonical[raw"\{"] = TeXExpr(:delimiter, '{')
 command_to_canonical[raw"\}"] = TeXExpr(:delimiter, '}')
 

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -101,6 +101,9 @@ end
     tex = L"Momentum $p_x$ (a.u.)"
     generate_tex_elements(tex)
 
+    tex = L"Average $\overline{an}_i$"
+    @test length(generate_tex_elements(tex)) == 12
+
     elems = generate_tex_elements(L"Time $t_0$")
     @test length(elems) == 7
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -144,6 +144,14 @@ end
         )
     end
 
+    @testset "Overline" begin
+        test_parse(raw"\overline{x}", (:overline, 'x'))
+        test_parse(
+            raw"\overline{abc}",
+            (:overline, (:group, 'a', 'b', 'c'))
+        )
+    end
+
     @testset "Space" begin
         test_parse(raw"\quad", (:space, 1))
         test_parse(raw"\qquad", (:space, 2))


### PR DESCRIPTION
I implemented the support for the overline command basically by pattern recognition of how the `\sqrt` implementation works. I can't say I fully understood every line, therefore it would be good if somebody can double check if I missed something. Especially the layout part.

Also added basic tests for parsers and layouts handling of overline.

This fixes issue #79.

