### PR TITLE
Switch \epsilon and \varepsilon

### DIFF
--- a/src/engine/new_computer_modern_data.jl
+++ b/src/engine/new_computer_modern_data.jl
@@ -3,14 +3,14 @@ _latex_to_new_computer_modern = Dict(
     raw"\sum" => 5941,
 
     raw"\partial" => 3377,
-    raw"\varepsilon" => 3378,
+    raw"\varepsilon" => 3356,
     raw"\vartheta" => 3379,
     raw"\varkappa" => 3380,
     raw"\varphi" => 3373,
     raw"\varrho" => 3382,
     raw"\varpi" => 3383,
 
-    raw"\epsilon" => 3356,
+    raw"\epsilon" => 3378,
     raw"\theta" => 3359,
     raw"\kappa" => 3361,
     raw"\phi" => 3381,


### PR DESCRIPTION
Because they are flipped. I am quite sure that this used to be correct.

See also the unicode equivalent.

![image](https://user-images.githubusercontent.com/6280307/227781057-d0921254-39c5-47f6-b096-0dbd81ce74c5.png)
