### PR TITLE
Initial layout for matrices

### DIFF
--- a/src/parser/commands_data.jl
+++ b/src/parser/commands_data.jl
@@ -110,5 +110,12 @@ punctuation_symbols = split(raw", ; . !")
 delimiter_symbols = split(raw"| / ( ) [ ] < >")
 font_names = split(raw"rm cal it tt sf bf default bb frak scr regular")
 
+##
+## Env
+##
+
+supported_env = split("matrix pmatrix bmatrix")
+
+
 # TODO Add to the parser what come below, if needed
 wide_accent_commands = split(raw"\widehat \widetilde \widebar")

--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -65,6 +65,8 @@ command_to_canonical[raw"\sqrt"] = TeXExpr(:argument_gatherer, [:sqrt, 1])
 command_to_canonical[raw"\overline"] = TeXExpr(:argument_gatherer, [:overline, 1])
 command_to_canonical[raw"\{"] = TeXExpr(:delimiter, '{')
 command_to_canonical[raw"\}"] = TeXExpr(:delimiter, '}')
+command_to_canonical[raw"\begin"] = TeXExpr(:argument_gatherer, [:begin_env, 1])
+command_to_canonical[raw"\end"] = TeXExpr(:argument_gatherer, [:end_env, 1])
 
 ##
 ## Commands from the commands_data.jl file

--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -65,6 +65,8 @@ command_to_canonical[raw"\sqrt"] = TeXExpr(:argument_gatherer, [:sqrt, 1])
 command_to_canonical[raw"\overline"] = TeXExpr(:argument_gatherer, [:overline, 1])
 command_to_canonical[raw"\{"] = TeXExpr(:delimiter, '{')
 command_to_canonical[raw"\}"] = TeXExpr(:delimiter, '}')
+
+# Commands for env
 command_to_canonical[raw"\begin"] = TeXExpr(:argument_gatherer, [:begin_env, 1])
 command_to_canonical[raw"\end"] = TeXExpr(:argument_gatherer, [:end_env, 1])
 

--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -51,6 +51,8 @@ function get_symbol_char(command)
     return first(latex_symbols[command])
 end
 
+is_supported(env) = env in supported_env
+
 # Numbers
 for char in join(0:9)
     symbol_to_canonical[char] = TeXExpr(:digit, char)

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -135,7 +135,7 @@ function _end_group!(stack, p, data)
     current_head(stack) == :skip_char && return
     
     current_head(stack) != :group && throw(
-        TeXParseError("Unexpected '}' at position $(p-1)", stack, p, data))
+        TeXParseError("unexpected '}'", stack, p, data))
     group = pop!(stack)
 
     # Remplace empty groups by a zero-width space
@@ -162,11 +162,16 @@ function _end_group!(stack, p, data)
                 push!(stack, TeXExpr(:env, Any[env_name]))
             elseif head == :end_env
                 env_name = String(Char.(args[1].args))
-                current_env_name = current(stack).args[1]
-                env_name != current_env_name && throw(
+                current(stack).head != :env && throw(
                     TeXParseError(
-                        "Found an end for environnement '$env_name', but it is \
-                        not matching the currently open env '$current_env_name'",
+                        "unexpected end of environnement '$env_name'",
+                    stack, p, data))
+
+                open_env_name = current(stack).args[1]
+                env_name != open_env_name && throw(
+                    TeXParseError(
+                        "found an end for environnement '$env_name', but it is \
+                        not matching the currently open env '$open_env_name'",
                     stack, p, data))
                 env = pop!(stack)
                 push_to_current!(stack, env)

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -16,7 +16,7 @@ function show_state(io::IO, stack, position, data)
     if position > lastindex(data)
         println(io, "after the end of the data")
         println(io, data)
-    else
+    elseif position > 0
         # Compute the index of the char from the byte index
         position_to_id = zeros(Int, lastindex(data))
         id = 0

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -176,8 +176,7 @@ function _end_group!(stack, p, data)
                 open_env_name = current(stack).args[1]
                 env_name != open_env_name && throw(
                     TeXParseError(
-                        "found an end for environnement '$env_name', but it is \
-                        not matching the currently open env",
+                        "found an end for environnement '$env_name', but it is not matching the currently open env",
                     stack, p, data))
                 env = pop!(stack)
                 push_to_current!(stack, env)

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -159,6 +159,10 @@ function _end_group!(stack, p, data)
             if head == :begin_env
                 # Transform the content of the argument back to a single string
                 env_name = String(Char.(first(args).args))
+                !is_supported(env_name) && throw(
+                    TeXParseError(
+                        "env '$env_name' is not supported",
+                        stack, p, data))
                 push!(stack, TeXExpr(:env, Any[env_name]))
                 push!(stack, TeXExpr(:env_row))
                 push!(stack, TeXExpr(:env_cell))
@@ -167,7 +171,7 @@ function _end_group!(stack, p, data)
                 current(stack).head != :env_cell && throw(
                     TeXParseError(
                         "unexpected end of environnement '$env_name'",
-                    stack, p, data))
+                        stack, p, data))
 
                 cell = pop!(stack)
                 push_to_current!(stack, cell)

--- a/src/parser/texexpr.jl
+++ b/src/parser/texexpr.jl
@@ -116,8 +116,53 @@ function AbstractTrees.printnode(io::IO, texexpr::TeXExpr)
     end
 end
 
-function Base.show(io::IO, texexpr::TeXExpr)
-    print_tree(io, texexpr, maxdepth=10)
+to_latex(::Nothing) = nothing
+
+function to_latex(texexpr::TeXExpr)
+    head = texexpr.head
+    args = texexpr.args
+
+    head in [:char, :digit, :punctuation, :symbol] && return string(first(args))
+    head == :function && return "\\$(first(args))"
+    head == :frac && return "\\frac{$(to_latex(args[1]))}{$(to_latex(args[2]))}"
+    head == :group && return join(to_latex.(args), " ")
+    head == :sqrt && return "\\sqrt{$(to_latex(first(args)))}"
+    head == :spaced && return string(first(first(args).args))
+    head == :space && return ""
+    
+    if head in [:decorated, :integral, :underover]
+        core, sub, sup = to_latex.(args)
+
+        if !isnothing(sub)
+            if length(sub) == 1
+                core *= "_$sub"
+            else
+                core *= "_{$sub}"
+            end
+        end
+
+        if !isnothing(sup)
+            if length(sup) == 1
+                core *= "^$sup"
+            else
+                core *= "^{$sup}"
+            end
+        end
+        return core
+    end
+
+    # TODO :accent, :space properly
+
+    # Fallback
+    return "to_latex($texexpr)"
+end
+
+function Base.show(io::IO, ::MIME"text/plain", texexpr::TeXExpr)
+    if haskey(io, :compact) && io[:compact]
+        print(io, "TeX\"$(to_latex(texexpr))\"")
+    else
+        return print_tree(io, texexpr, maxdepth=10)
+    end
 end
 
 function Base.:(==)(tex1::TeXExpr, tex2::TeXExpr)


### PR DESCRIPTION
This builds on the work in #56 (which itself builds on #50). All those commits
have been rebased onto master for convience.

I implemented a simple layout algorithm for matrices (only supports `matrix`
right now, but extending to include `pmatrix` and `bmatrix` should be possible).
It works quite well for simple entries, although perhaps the entries should be
centered horizontally and vertically.
[test.pdf](https://github.com/Kolaru/MathTeXEngine.jl/files/13320148/test.pdf)

However, you can see that the layout is very poor when taller notation (e.g.
fractions) are used. I think this results from a misunderstanding on my part of
how they layout is done. In the second attached pdf, you can see pairs of
horizontal lines where I think the symbols should be, which disagrees quite
dramatically with where they are.
[test_vert_extent.pdf](https://github.com/Kolaru/MathTeXEngine.jl/files/13320147/test_vert_extent.pdf)

