### PR TITLE
New parser - simplified with a tokenizer pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MathTeXEngine"
 uuid = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"
 authors = ["Benoît Richard <kolaru@hotmail.com>"]
-version = "0.5.7"
+version = "0.6.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The table below contains the list of all supported LaTeX construction and their 
 | Function | `\sin` | `:function` | `name` |
 | Generic symbol | `ω` | `:symbol` | `unicode_char` |
 | Group | `{ }` | `:group` | `elements...` |
+| Inline math | `$ $` | `:inline_math` | `content` |
 | Integral | `\int_a^b` | `:integral` | `symbol, low_bound, high_bound` |
 | Math fonts | `\mathrm{}` | `:font` | `font_modifier, expr` |
 | Punctuation | `!` | `:punctuation` |

--- a/src/MathTeXEngine.jl
+++ b/src/MathTeXEngine.jl
@@ -19,7 +19,7 @@ import FreeTypeAbstraction:
     height_insensitive_boundingbox, leftinkbound, rightinkbound,
     topinkbound, bottominkbound
 
-export TeXExpr, texparse, TeXParseError
+export TeXExpr, texparse, TeXParseError, manual_texexpr
 export TeXElement, TeXChar, VLine, HLine, generate_tex_elements
 export texfont
 export glyph_index

--- a/src/MathTeXEngine.jl
+++ b/src/MathTeXEngine.jl
@@ -19,7 +19,7 @@ import FreeTypeAbstraction:
     height_insensitive_boundingbox, leftinkbound, rightinkbound,
     topinkbound, bottominkbound
 
-export TeXExpr, texparse
+export TeXExpr, texparse, TeXParseError
 export TeXElement, TeXChar, VLine, HLine, generate_tex_elements
 export texfont
 export glyph_index
@@ -27,6 +27,7 @@ export glyph_index
 # Reexport from LaTeXStrings
 export @L_str
 
+include("parser/tokenizer.jl")
 include("parser/texexpr.jl")
 include("parser/commands_data.jl")
 include("parser/commands_registration.jl")

--- a/src/engine/layout_context.jl
+++ b/src/engine/layout_context.jl
@@ -1,16 +1,22 @@
 struct LayoutState
     font_family::FontFamily
     font_modifiers::Vector{Symbol}
+    tex_mode::Symbol
 end
 
+LayoutState(font_family::FontFamily, modifiers::Vector) = LayoutState(font_family, modifiers, :text)
 LayoutState(font_family::FontFamily) = LayoutState(font_family, Symbol[])
 LayoutState() = LayoutState(FontFamily())
 
-Base.broadcastable(state::LayoutState) = [state]
+Base.broadcastable(state::LayoutState) = Ref(state)
+
+function change_mode(state::LayoutState, mode)
+    LayoutState(state.font_family, state.font_modifiers, mode)
+end
 
 function add_font_modifier(state::LayoutState, modifier)
-    modifiers = [state.font_modifiers..., modifier]
-    return LayoutState(state.font_family, modifiers)
+    modifiers = vcat(state.font_modifiers, modifier)
+    return LayoutState(state.font_family, modifiers, state.tex_mode)
 end
 
 function get_font(state::LayoutState, char_type)

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -94,7 +94,7 @@ end
 function delimiter(com_str, str)
     str = str[length(com_str)+1:end]
     if length(str) == 1
-        return TeXExpr(:char, only(str))
+        return TeXExpr(:delimiter, only(str))
     else
         return only(texparse(str).args)
     end
@@ -145,7 +145,7 @@ function texparse(tex ; root = TeXExpr(:expr), showdebug = false)
                 left_delim, content... = delimited.args
                 right_delim = delimiter(raw"\right", tex[pos:pos+len-1])
                 if length(content) == 1
-                    content = TeXExpr(:char, only(content))
+                    content = only(content)
                 else
                     content = TeXExpr(:group, content)
                 end

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -2,42 +2,41 @@ struct TeXParseError <: Exception
     msg::String
     stack::Stack
     position::Int
-    data
+    tex
 end
 
 function Base.showerror(io::IO, e::TeXParseError)
     println(io, "TeXParseError: ",  e.msg)
-    show_state(io, e.stack, e.position, e.data)
+    show_state(io, e.stack, e.position, e.tex)
 end
 
-function show_state(io::IO, stack, position, data)
+function show_state(io::IO, stack, position, tex)
     # Everything is shifted by one
-    position -= 1
-    if position > lastindex(data)
-        println(io, "after the end of the data")
-        println(io, data)
+    if position > lastindex(tex)
+        println(io, "after the end of the latex string")
+        println(io, tex)
     else
         # Compute the index of the char from the byte index
-        position_to_id = zeros(Int, lastindex(data))
+        position_to_id = zeros(Int, lastindex(tex))
         id = 0
-        for p in 1:lastindex(data)
-            if isvalid(data, p)
+        for p in 1:lastindex(tex)
+            if isvalid(tex, p)
                 id += 1
             end
             position_to_id[p] = id
         end
         p = position_to_id[position]
         println(io, "at position ", position, " (string index ", p, ")")
-        println(io, data)
+        println(io, tex)
         println(io, " " ^ (p - 1), "^")
     end
 
-    println(io, "Stack before")
+    println(io, "Stack")
     show_stack(io, stack)
     println(io)
 end
 
-show_state(stack, position, data) = show_state(stdout, stack, position, data)
+show_state(stack, position, tex) = show_state(stdout, stack, position, tex)
 
 function show_stack(io, stack)
     for (k, level) in enumerate(stack)
@@ -48,276 +47,61 @@ end
 
 show_stack(stack) = show_stack(stdout, stack)
 
-function show_debug_info(stack, position, data, action_name)
-    @info "Action " * String(action_name)
-    show_state(stack, position, data)
-end
-
-machine = let
-    # Super and subscript
-    super = onexit!(re"\^", [:end_command_builder, :setup_decorated, :begin_super]) 
-    sub = onexit!(re"_", [:end_command_builder, :setup_decorated, :begin_sub])
-
-    # Groups
-    lbrace = onexit!(re"{", [:end_command_builder, :begin_group])
-    rbrace = onexit!(re"}", [:end_command_builder, :end_group, :end_token])
-
-    # Commands
-    bslash = onexit!(re"\\", [:end_command_builder, :begin_command_builder])
-    command_char = onexit!(re"[A-Za-z]", [:push_char, :end_token])
-
-    # Characters
-    space = onexit!(re" ", [:end_command_builder, :push_space])
-    special_char = lbrace | rbrace | bslash | super | sub | command_char | space
-    other_char = onexit!(
-        re"." \ special_char,
-        [:end_command_builder, :push_char, :end_token]
-    )
-
-    mathexpr = onexit!(Automa.rep(special_char | other_char), :end_command_builder)
-
-    Automa.compile(mathexpr)
-end
-
-current(stack) = first(stack)
-current_head(stack) = head(current(stack))
-push_to_current!(stack, arg) = push!(current(stack).args, arg)
-
-const require_token = [
-    :subscript,
-    :superscript,
-    :left_delimiter,
-    :right_delimiter
-]
-
-function requirement(stack)
-    current_head(stack) == :argument_gatherer && return :argument
-    current_head(stack) in require_token && return :token
-    return :none
-end
-
-function end_token!(stack)
-    requirement(stack) != :token && return
-    token = pop!(stack)
-
-    if current_head(stack) in [:decorated, :underover, :integral]
-        decorated = pop!(stack)
-        id = head(token) == :subscript ? 2 : 3
-        
-        !isnothing(decorated.args[id]) && throw(
-            TeXParseError("multiple subscripts or superscripts", stack, p, data))
-        decorated.args[id] = first(token.args)
-        push_to_current!(stack, decorated)
-    elseif head(token) == :left_delimiter
-        push_to_current!(stack, token)
-    elseif head(token) == :right_delimiter
-        push_to_current!(stack, token)
-        delimited = pop!(stack)
-
-        # Simplify by constructing a single :delimited expr
-        left = delimited.args[1]
-        right = delimited.args[end]
-        args = delimited.args[2:end-1]
-        content = length(args) == 1 ? first(args) : TeXExpr(:group, args)
-        simplified = TeXExpr(:delimited, [left.args[1], content, right.args[1]])
-        push_to_current!(stack, simplified)
-    end
-end
-
-# Set all command as function to play more nicely with Revise.jl
-
-function _begin_group!(stack, p, data)
-    current_head(stack) == :skip_char && return
-    push!(stack, TeXExpr(:group))
-end
-
-function _end_group!(stack, p, data)
-    current_head(stack) == :skip_char && return
-    
-    current_head(stack) != :group && throw(
-        TeXParseError("Unexpected '}' at position $(p-1)", stack, p, data))
-    group = pop!(stack)
-
-    # Remplace empty groups by a zero-width space
-    if isempty(group.args)
-        group = TeXExpr(:space, 0.0)
-    # Remove nestedness for group with a single element
-    elseif length(group.args) == 1
-        group = first(group.args)
-    end
-
-    if requirement(stack) == :argument
-        push_to_current!(stack, group)
-
-        command_builder = current(stack)
-        head, required_n_args = command_builder.args[1:2]
-        args = command_builder.args[3:end]
-
-        # Check if the argument gatherer got all the needed arguments
-        if required_n_args == length(args)
-            pop!(stack)
-            command = TeXExpr(head, args)
-            push_to_current!(stack, command)
+function push_down!(stack)
+    top = pop!(stack)
+    if head(top) == :group
+        # Replace empty groups by 0 spaces
+        if isempty(top.args)
+            top = TeXExpr(:space, 0.0)
+        # Unroll group with single elements
+        elseif length(top.args) == 1
+            top = only(top.args)
         end
-    else
-        push_to_current!(stack, group)
     end
+    push!(first(stack), top)
+
+    if head(first(stack)) in [:subscript, :superscript]
+        decoration = pop!(stack)
+        decorated = pop!(first(stack)) 
+        decorated.args[subsuperindex(head(decoration))] = first(decoration.args)
+        push!(first(stack).args, decorated)
+    end 
+
+    conclude_command!!(stack)
 end
 
-function _push_char!(stack, p, data)
-    if current_head(stack) == :skip_char
+function conclude_command!!(stack)
+    com = first(stack) 
+    head(com) != :command && return false
+    nargs = length(com.args) - 1
+
+    if required_args(first(com.args)) == nargs
         pop!(stack)
-    elseif isvalid(data, p-1)
-        char = data[prevind(data, p)]
-        push_to_current!(stack, canonical_expr(char))
+        push!(stack, command_expr(com.args[1], com.args[2:end]))
+        push_down!(stack)
     end
 end
 
-function _push_space!(stack, p, data)
-    if current_head(stack) == :group
-        # Pop the head to peak at the parent
-        group = pop!(stack)
-        if current_head(stack) == :argument_gatherer && current(stack).args[1] == :text
-            push!(group.args, canonical_expr(' '))
-        end
-        # Put back the group to restore the stack
-        push!(stack, group)
+function subsuperindex(dec)
+    if dec == :subscript
+        return 2
+    elseif dec == :superscript
+        return 3
     end
+    error()
 end
 
-function _end_token!(stack, p, data)
-    if isvalid(data, p-1)
-        end_token!(stack)
-    end
-end
-
-_begin_sub!(stack, p, data) = push!(stack, TeXExpr(:subscript))
-_begin_super!(stack, p, data) = push!(stack, TeXExpr(:superscript))
-
-function _setup_decorated!(stack, p, data)
-    core = pop!(current(stack).args)
-    if head(core) ∉ [:decorated, :integral, :underover]
-        push!(stack, TeXExpr(:decorated, Any[core, nothing, nothing]))
+function delimiter(com_str, str)
+    str = str[length(com_str)+1:end]
+    if length(str) == 1
+        return TeXExpr(:char, only(str))
     else
-        push!(stack, core)
+        return only(texparse(str).args)
     end
 end
 
-_begin_command_builder!(stack, p, data) = push!(stack, TeXExpr(:command_builder))
-
-function _end_command_builder!(stack, p, data)
-    if current_head(stack) == :command_builder
-        command_builder = pop!(stack)
-
-        args = command_builder.args
-        skip_char = false
-
-        # One character command are always tested even if the char is not
-        # a letter
-        if length(args) == 0
-            current_char = data[prevind(data, p)]
-            push!(args, current_char)
-            skip_char = true
-        end
-
-        command_name = String(Char.(args))
-        command = "\\" * command_name
-
-        if command_name == "left"
-            push!(stack, TeXExpr(:delimited))
-            push!(stack, TeXExpr(:left_delimiter))
-        elseif command_name == "right"
-            current_head(stack) != :delimited && throw(
-                TeXParseError("unexpected '\\right' at position $(p-1)",
-                stack, p, data))
-            push!(stack, TeXExpr(:right_delimiter))
-        elseif haskey(command_to_canonical, command)
-            expr = command_to_canonical[command]
-
-            if head(expr) == :argument_gatherer
-                push!(stack, expr)
-            else
-                push_to_current!(stack, expr)
-                end_token!(stack)
-            end
-        else
-            throw(
-                TeXParseError("unsupported command $command",
-                stack, p, data))
-        end
-
-        if skip_char 
-            push!(stack, TeXExpr(:skip_char))
-        end
-    end
-end
-
-action_names = [
-    :begin_group, :end_group, :push_char, :push_space, :end_token, :begin_sub, :begin_super,
-    :setup_decorated, :begin_command_builder, :end_command_builder]
-
-actions = map(action_names) do action_name
-    function_name = Symbol("_" * String(action_name) * "!")
-
-    return action_name => quote
-        if showdebug
-            show_debug_info(stack, p, data, $(QuoteNode(action_name)))
-        end
-
-        $function_name(stack, p, data)
-
-        if showdebug
-            println("Stack after")
-            show_stack(stack)
-            println()
-        end
-    end
-end
-
-actions = Dict(actions...)
-
-@eval function texparse(data ; showdebug=false)
-    # Allows string to start with _ or ^
-    if !isempty(data) && (data[1] == '_' || data[1] == '^')
-        data = "{}" * data
-    end
-
-    $(Automa.generate_init_code(machine))
-    # Needed to avoid problem with multi bytes unicode chars
-    stack = Stack{Any}()
-    push!(stack, TeXExpr(:expr))
-
-    try
-        $(Automa.generate_exec_code(machine, actions))
-    catch e
-        if e isa TeXParseError
-            rethrow()
-        else
-            throw(TeXParseError("unexpected error while parsing", stack, p, data))
-        end
-    end
-
-    while current_head(stack) == :skip_char
-        pop!(stack)
-    end
-
-    if length(stack) > 1 
-        err = TeXParseError(
-            "end of string reached with unfinished $(current(stack).head)",
-            stack, p, data)
-        throw(err)
-    end
-
-    final_expr = current(stack)
-    # Never return an empty expression
-    if isempty(final_expr.args)
-        push!(final_expr.args, TeXExpr(:space, 0.0))
-    end
-    return final_expr
-end
-
-@doc """
-    texparse(data::String ; showdebug=false)
+"""
+    texparse(tex::String ; showdebug=false)
 
 Parse a string representing a single LaTeX expression into nested TeXExpr.
 
@@ -325,12 +109,82 @@ See the documentation for the possible combinations of expression head and
 arguments.
 
 Setting `showdebug` to `true` show a very verbose break down of the parsing.
-""" texparse
-
 """
-    texparse(data::LaTeXString ; showdebug=false)
+function texparse(tex ; root = TeXExpr(:expr), showdebug = false)
+    stack = Stack{Any}()
+    push!(stack, root)
 
-Parse a LaTeXString composed of a single LaTeX math expression into nested
-TeXExpr.
-"""
-texparse(data::LaTeXString ; showdebug=false) = texparse(data[2:end-1] ; showdebug=showdebug)
+    for (pos, len, token) in tokenize(TeXToken, tex)
+        if showdebug
+            show_state(stack, pos, tex)
+        end
+        # Skip the invalid part of unicode characters
+        !isvalid(tex, pos) && continue
+
+        try
+            if token == dollar
+                if head(first(stack)) == :inline_math
+                    push_down!(stack)
+                else
+                    push!(stack, TeXExpr(:inline_math))
+                end
+            elseif token == lcurly
+                push!(stack, TeXExpr(:group))
+            elseif token == rcurly
+                if head(first(stack)) != :group
+                    throw(TeXParseError("missing closing '}'", stack, pos, tex))
+                end
+                push_down!(stack)
+            elseif token == left
+                push!(stack, TeXExpr(:delimited, delimiter(raw"\left", tex[pos:pos+len-1])))
+            elseif token == right
+                delimited = pop!(stack)
+                if head(delimited) != :delimited
+                    throw(TeXParseError("missing closing delimiter", stack, pos, tex))
+                end
+                left_delim, content... = delimited.args
+                right_delim = delimiter(raw"\right", tex[pos:pos+len-1])
+                if length(content) == 1
+                    content = TeXExpr(:char, only(content))
+                else
+                    content = TeXExpr(:group, content)
+                end
+
+                push!(first(stack), TeXExpr(:delimited, [left_delim, content, right_delim]))
+            elseif token == command
+                com_str = tex[pos:pos+len-1]
+                push!(stack, TeXExpr(:command, [com_str]))
+                conclude_command!!(stack)
+            elseif token == underscore || token == caret
+                dec = token == underscore ? :subscript : :superscript
+
+                if isempty(first(stack).args)
+                    core = TeXExpr(:space, 0.0)
+                else
+                    core = pop!(first(stack))
+                end
+
+                if !(head(core) in [:decorated, :underover, :integral])
+                    core = TeXExpr(:decorated, [core, nothing, nothing])
+                end
+
+                if !isnothing(core.args[subsuperindex(dec)])
+                    throw(TeXParseError("multiple $token given", stack, pos, tex))
+                end
+
+                push!(first(stack), core)
+                push!(stack, TeXExpr(dec))
+            elseif token == char
+                push!(stack, canonical_expr(tex[pos])) 
+                push_down!(stack)
+            end
+        catch err
+            throw(TeXParseError("unexpected error", stack, pos, tex))
+        end
+    end
+
+    if length(stack) > 1
+        throw(TeXParseError("unexpected end of input", stack, length(tex), tex))
+    end
+    return only(stack)
+end

--- a/src/parser/texexpr.jl
+++ b/src/parser/texexpr.jl
@@ -20,7 +20,7 @@ Fields
 """
 struct TeXExpr
     head::Symbol
-    args::Vector
+    args::Vector{Any}
 
     function TeXExpr(head, args::Vector)
         # Convert math font like `\mathbb{R}` -- TeXExpr(:font, [:bb, 'R']) --
@@ -41,6 +41,10 @@ end
 TeXExpr(head) = TeXExpr(head, [])
 TeXExpr(head, args...) = TeXExpr(head, collect(args))
 TeXExpr(head, arg) = TeXExpr(head, [arg])
+
+Base.push!(texexpr::TeXExpr, arg) = push!(texexpr.args, arg)
+Base.pop!(texexpr::TeXExpr) = pop!(texexpr.args)
+Base.copy(texexpr::TeXExpr) = TeXExpr(texexpr.head, deepcopy(texexpr.args))
 
 function Base.Char(texexpr::TeXExpr)
     if texexpr.head in [:char, :symbol, :digit]
@@ -100,8 +104,6 @@ head(texexpr::TeXExpr) = texexpr.head
 head(::Char) = :char
 isleaf(texexpr::TeXExpr) = texexpr.head in (:char, :delimiter, :digit, :punctuation, :symbol)
 isleaf(::Nothing) = true
-
-Base.copy(texexpr::TeXExpr) = TeXExpr(texexpr.head, deepcopy(texexpr.args))
 
 function AbstractTrees.children(texexpr::TeXExpr)
     isleaf(texexpr) && return TeXExpr[]

--- a/src/parser/texexpr.jl
+++ b/src/parser/texexpr.jl
@@ -89,7 +89,7 @@ function manual_texexpr(tuple::Tuple)
 end
 
 function manual_texexpr(str::LaTeXString)
-    expr = texparse(str[2:end])
+    expr = texparse(str[2:end-1])
     if length(expr.args) == 1
         return first(expr.args)
     else

--- a/src/parser/tokenizer.jl
+++ b/src/parser/tokenizer.jl
@@ -1,0 +1,16 @@
+tex_tokens = [
+    :char => re".",
+    :caret => re"\^",
+    :underscore => re"_",
+    :rcurly => re"}",
+    :lcurly => re"{",
+    :command => re"\\[a-zA-Z]+" | re"\\.",
+    :right => re"\\right.",
+    :left => re"\\left.",
+    :dollar => re"$"
+]
+
+@eval @enum TeXToken error $(first.(tex_tokens)...)
+make_tokenizer((error, 
+    [TeXToken(i) => j for (i, j) in enumerate(last.(tex_tokens))]
+)) |> eval

--- a/test/layout.jl
+++ b/test/layout.jl
@@ -88,10 +88,10 @@ end
 end
 
 @testset "Generate elements" begin
-    elems = generate_tex_elements("a + b")
+    elems = generate_tex_elements(L"a + b")
     @test length(elems) == 3
 
-    elems = generate_tex_elements(raw"{{a + b} - {c * d}}")
+    elems = generate_tex_elements(L"{{a + b} - {c * d}}")
     @test length(elems) == 7
 
     # Check the following does not error

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -22,17 +22,17 @@ end
 
     @testset "Delimiter" begin
         test_parse(
-            raw"\left( x \right)",
+            raw"\left(x\right)",
             (:delimited, '(', 'x', ')')
         )
 
         test_parse(
-            raw"\left[ y \right)",
+            raw"\left[y\right)",
             (:delimited, '[', 'y', ')')
         )
 
         test_parse(
-            raw"\left( a + b \right)",
+            raw"\left(a+b\right)",
             (:delimited,
                 '(',
                 (:group, 'a', (:spaced, '+'), 'b'),
@@ -46,8 +46,6 @@ end
 
         @test_throws TeXParseError texparse(raw"\left( x")
         @test_throws TeXParseError texparse(raw"x \right)")
-
-        # TODO Recursive delim
     end
 
     @testset "Fonts" begin
@@ -57,6 +55,7 @@ end
         test_parse(raw"\mathrm{u v}", (:text, :rm, 
             (:group,
                 (:char, 'u'),
+                (:char, ' '),
                 (:char, 'v')
             )))
         test_parse(raw"\text{u v}", (:text, :rm, 
@@ -65,6 +64,8 @@ end
                 (:char, ' '),
                 (:char, 'v')
             )))
+
+        @test texparse(raw"ℝ") == texparse(raw"\mathbb{R}")
     end
 
     @testset "Fraction" begin
@@ -109,8 +110,7 @@ end
     end
 
     @testset "LaTeXString input" begin
-        @test texparse(raw"\gamma") == texparse(L"\gamma")
-        @test texparse(raw"ℝ") == texparse(raw"\mathbb{R}")
+        @test texparse(raw"$\gamma$") == texparse(L"\gamma")
     end
 
     @testset "Overunder" begin

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -21,6 +21,12 @@ end
     end
 
     @testset "Delimiter" begin
+        expr = texparse(L"\left(\frac{x}{y}\right)")
+        delimited = expr.args[1].args[1]
+        @test delimited.args[1].head == :delimiter
+        @test delimited.args[2].head == :frac
+        @test delimited.args[3].head == :delimiter
+
         test_parse(
             raw"\left(x\right)",
             (:delimited, '(', 'x', ')')
@@ -42,7 +48,6 @@ end
 
         test_parse(raw"\{", (:delimiter, '{'))
         test_parse(raw"\}", (:delimiter, '}'))
-
 
         @test_throws TeXParseError texparse(raw"\left( x")
         @test_throws TeXParseError texparse(raw"x \right)")


### PR DESCRIPTION
Fix #100 

The new parser is easier to understand and should help with issues that require to modify it.

This is breaking because know spaces are always kept, they are discarded in math mode during layouting.

Also `$ .. $` are now parsed as a `:inline_math` TeXExpr, opening the road for proper line breaks.