### PR TITLE
Support for line break

### DIFF
--- a/reference/references.jl
+++ b/reference/references.jl
@@ -115,7 +115,7 @@ function single_figure(exprs)
     failures = Dict()
     for (i, expr) in enumerate(exprs)
         try
-            fig[i, 1] = Label(fig, expr)
+            Label(fig[i, 1], expr)
         catch e
             failures[expr] = e
         end 

--- a/reference/references.jl
+++ b/reference/references.jl
@@ -49,6 +49,10 @@ inputs["integrals"] = [
     L"\int \int \int"
 ]
 
+input["linebreaks"] = [
+    L"we clearly see $x = 22$\\and $y > x^2$"
+]
+
 inputs["punctuation"] = [
     L"x!",
     L"23.17",

--- a/src/MathTeXEngine.jl
+++ b/src/MathTeXEngine.jl
@@ -19,6 +19,7 @@ import FreeTypeAbstraction:
     height_insensitive_boundingbox, leftinkbound, rightinkbound,
     topinkbound, bottominkbound
 
+export TeXToken, tokenize
 export TeXExpr, texparse, TeXParseError, manual_texexpr
 export TeXElement, TeXChar, VLine, HLine, generate_tex_elements
 export texfont

--- a/src/engine/layout.jl
+++ b/src/engine/layout.jl
@@ -161,6 +161,15 @@ function tex_layout(expr, state)
             )
         elseif head == :lines
             length(args) == 1 && return tex_layout(only(args), state)
+            lineheight = 1.3
+            lines = tex_layout.(args, state)
+            points = map(enumerate(lines)) do (k, line)
+                x = -inkwidth(line) / 2
+                y = (1 - k)*lineheight
+                return Point2f(x, y)
+            end
+
+            return Group(lines, points)
         elseif head == :overline
             content = tex_layout(args[1], state)
 

--- a/src/engine/layout_context.jl
+++ b/src/engine/layout_context.jl
@@ -20,6 +20,10 @@ function add_font_modifier(state::LayoutState, modifier)
 end
 
 function get_font(state::LayoutState, char_type)
+    if state.tex_mode == :text
+        char_type = :text
+    end
+
     font_family = state.font_family
     font_id = font_family.font_mapping[char_type]
 

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -111,12 +111,6 @@ arguments.
 Setting `showdebug` to `true` show a very verbose break down of the parsing.
 """
 function texparse(tex ; root = TeXExpr(:lines), showdebug = false)
-    if tex[1] == '$' && tex[end] == '$' && !('$' in tex[2:end-1])
-        @info "Just one latex equation"
-        tex = tex[2:end-1]
-    end
-    @show tex
-
     stack = Stack{Any}()
     push!(stack, root)
     push!(stack, TeXExpr(:line))

--- a/src/parser/parser.jl
+++ b/src/parser/parser.jl
@@ -203,5 +203,11 @@ function texparse(tex ; root = TeXExpr(:lines), showdebug = false)
     if length(stack) > 1
         throw(TeXParseError("unexpected end of input", stack, length(tex), tex))
     end
-    return only(stack)
+
+    lines = only(stack)
+    if length(lines.args) == 1
+        return only(lines.args)
+    else
+        return lines
+    end
 end

--- a/src/parser/tokenizer.jl
+++ b/src/parser/tokenizer.jl
@@ -8,6 +8,7 @@ tex_tokens = [
     :command => re"\\[a-zA-Z]+" | re"\\.",
     :right => re"\\right.",
     :left => re"\\left.",
+    :newline => (re"\\" * re"\\") | re"\\n",
     :dollar => re"$"
 ]
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -1,5 +1,5 @@
 function test_parse(input, args... ; broken=false)
-    arg = (:expr, args...)
+    arg = (:line, args...)
     if broken
         @test_broken texparse(input) == manual_texexpr(arg)
     else
@@ -112,6 +112,12 @@ end
             raw"\int_a^b",
             (:integral, (:symbol, '∫'), 'a', 'b')
         )
+    end
+
+    @testset "Linebreak" begin
+        expr = texparse(L"$A$\\$B$\\$C$")
+        @test expr.head == :lines
+        @test length(expr.args) == 3
     end
 
     @testset "LaTeXString input" begin


### PR DESCRIPTION
Line break can be created with `\\`.

The line break must not be inside an equation, e.g. `$a \\ b$` is invalid.