### PR TITLE
Replace hyphen for minus sign only inside math

### DIFF
--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -110,10 +110,6 @@ for symbol in spaced_symbols
     symbol_to_canonical[symbol] = TeXExpr(:spaced, symbol_expr)
 end
 
-# Special case for hyphen that must be replaced by a minus sign
-# TODO Make sure it is not replaced outside of math mode and when starting a group
-symbol_to_canonical['-'] = TeXExpr(:spaced, TeXExpr(:symbol, '−'))
-
 for com_str in spaced_commands
     symbol = get_symbol_char(com_str)
     symbol_expr = TeXExpr(:symbol, symbol)

--- a/src/parser/texexpr.jl
+++ b/src/parser/texexpr.jl
@@ -125,7 +125,7 @@ end
 function Base.:(==)(tex1::TeXExpr, tex2::TeXExpr)
     childs1 = children(tex1)
     childs2 = children(tex2)
-    
+
     length(childs1) != length(childs2) && return false
 
     return all(childs1 .== childs2)
@@ -141,7 +141,7 @@ function leafmap(f, texexpr::TeXExpr)
     isleaf(texexpr) && return f(texexpr)
 
     args = map(texexpr.args) do arg
-        isnothing(arg) && return nothing
+        arg isa TeXExpr || return arg
         return leafmap(f, arg)
     end
 

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -56,14 +56,14 @@ end
     @testset "Fonts" begin
         test_parse(raw"\mathrm{u}", (:font, :rm, (:char, 'u')))
         test_parse(raw"\text{u}", (:text, :rm, (:char, 'u')))
-        
-        test_parse(raw"\mathrm{u v}", (:text, :rm, 
+
+        test_parse(raw"\mathrm{u v}", (:text, :rm,
             (:group,
                 (:char, 'u'),
                 (:char, ' '),
                 (:char, 'v')
             )))
-        test_parse(raw"\text{u v}", (:text, :rm, 
+        test_parse(raw"\text{u v}", (:text, :rm,
             (:group,
                 (:char, 'u'),
                 (:char, ' '),
@@ -177,6 +177,14 @@ end
         )
         # Hyphen must be replaced by a minus sign
         test_parse(raw"-", (:spaced, (:symbol, '−')))
+
+        test_parse(raw"a-b $c-d$",
+                   (:char, 'a'), (:char, '-'), (:char, 'b'),
+                   (:char, ' '),
+                   (:inline_math,
+                    (:char, 'c'),
+                    (:spaced, (:symbol, '−')),
+                    (:char, 'd')))
     end
 
     @testset "Subscript and superscript" begin


### PR DESCRIPTION
This commit improves the logic for replacing hyphens by minus signs. Before, every hyphen was replaced by a minus sign. Now, a hyphen is replaced by a minus sign only if the hyphen is inside inline math or if there is no inline math at all.

Examples:

  * `a - b` becomes `a − b` (hyphen replaced)
  * `Multi-dimensional $a - b$` becomes `Multi-dimensional $a − b$` (only the second hyphen replaced)

Closes #128

---

As I was working on this issue, I discovered a tiny imperfection inside `leafmap`, so I also updated that.