### PR TITLE
Simplify changing fonts

### DIFF
--- a/src/MathTeXEngine.jl
+++ b/src/MathTeXEngine.jl
@@ -22,7 +22,7 @@ import FreeTypeAbstraction:
 export TeXToken, tokenize
 export TeXExpr, texparse, TeXParseError, manual_texexpr
 export TeXElement, TeXChar, VLine, HLine, generate_tex_elements
-export texfont, FontFamily
+export texfont, FontFamily, set_texfont_family!, get_texfont_family
 export glyph_index
 
 # Reexport from LaTeXStrings

--- a/src/engine/fonts.jl
+++ b/src/engine/fonts.jl
@@ -108,6 +108,14 @@ e.g. L"\\fontfamily{TeXGyreHeros}x^2_3".
 FontFamily() = FontFamily("NewComputerModern")
 FontFamily(fontname::AbstractString) = default_font_families[fontname]
 
+function Base.show(io::IO, family::FontFamily)
+    println(io, "FontFamily with $(family.slant_angle)° slant angle and $(family.thickness) line thickness")
+    for (key, font) in family.fonts
+        spaces = " "^(12 - length(string(key)))
+        println(io, "  $key$spaces=>  $font")
+    end
+end
+
 # These two fonts internals are very different, despite their similar names
 # We only try to fully support NewComputerModern, the other is here as it may
 # sometime provide quickfix solution to bug


### PR DESCRIPTION
This PR introduces the `set_texfont_family` function, that can be used to more easily change the default font used by the engine:

```julia
# Change to a different font familiy entirely
julia> set_texfont_family!(FontFamily("LucioleMath"))
FontFamily with 13.0° slant angle and 0.0375 line thickness
  bold        =>  Luciole-Math\Luciole-Bold.ttf
  bolditalic  =>  Luciole-Math\Luciole-Bold-Italic.ttf
  italic      =>  Luciole-Math\Luciole-Regular-Italic.ttf
  math        =>  Luciole-Math\Luciole-Math.otf
  regular     =>  Luciole-Math\Luciole-Regular.ttf

# Change just the regular and bold fonts, keep the default for the rest
julia> set_texfont_family!(:regular => raw"C:\Users\Kolaru\.julia\dev\MathTeXEngine\experimental\utopia\Utopia-Regular.ttf", :bold=> raw"C:\Users\Kolaru\.julia\dev\MathTeXEngine\experimental\utopia\Utopia-Bold.ttf")
FontFamily with 13.0° slant angle and 0.0375 line thickness
  bold        =>  NewComputerModern\NewCM10-Bold.otf
  bolditalic  =>  NewComputerModern\NewCM10-BoldItalic.otf
  italic      =>  NewComputerModern\NewCM10-Italic.otf
  math        =>  NewComputerModern\NewCMMath-Regular.otf
  regular     =>  C:\Users\Kolaru\.julia\dev\MathTeXEngine\experimental\utopia\Utopia-Regular.ttf

# Switch back to the defaul
julia> set_texfont_family!()
FontFamily with 13.0° slant angle and 0.0375 line thickness
  bold        =>  NewComputerModern\NewCM10-Bold.otf
  bolditalic  =>  NewComputerModern\NewCM10-BoldItalic.otf
  italic      =>  NewComputerModern\NewCM10-Italic.otf
  math        =>  NewComputerModern\NewCMMath-Regular.otf
  regular     =>  NewComputerModern\NewCMMath-Regular.otf
```