### PR TITLE
Add UnicodeMath.jl -- mimic LaTeX package unicode-math for more control over font styles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 RelocatableFolders = "05181044-ff0b-4ac5-8273-598c1e38db00"
 UnicodeFun = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+UnicodeMath = "0d34d933-8ee7-410a-b7f5-1fe550df0327"
 
 [compat]
 AbstractTrees = "0.3, 0.4"

--- a/src/MathTeXEngine.jl
+++ b/src/MathTeXEngine.jl
@@ -7,6 +7,7 @@ using Automa
 using FreeTypeAbstraction
 using LaTeXStrings
 using UnicodeFun
+import UnicodeMath as UCM
 
 using DataStructures: Stack
 using GeometryBasics: Point2f, Rect2f

--- a/src/engine/fonts.jl
+++ b/src/engine/fonts.jl
@@ -29,12 +29,12 @@ end
 
 const _default_font_mapping = Dict(
     :text => :regular,
-    :delimiter => :regular,
-    :digit => :regular,
-    :function => :regular,
-    :punctuation => :regular,
+    :delimiter => :math,
+    :digit => :math,
+    :function => :math,
+    :punctuation => :math,
     :symbol => :math,
-    :char => :italic
+    :char => :math
 )
 
 const _default_font_modifiers = Dict(

--- a/src/engine/layout_context.jl
+++ b/src/engine/layout_context.jl
@@ -32,8 +32,9 @@ function get_font(state::LayoutState, char_type)
     font_id = font_family.font_mapping[char_type]
 
     for modifier in state.font_modifiers
+        @show modifier
         if haskey(font_family.font_modifiers, modifier)
-            mapping = font_family.font_modifiers[modifier]
+            @show mapping = font_family.font_modifiers[modifier]
             font_id = get(mapping, font_id, font_id)
         else
             throw(ArgumentError("font modifier $modifier not supported for the current font family."))

--- a/src/parser/commands_registration.jl
+++ b/src/parser/commands_registration.jl
@@ -94,6 +94,11 @@ for name in font_names
 end
 command_definitions["\\text"] = (TeXExpr(:text, :rm), 1)
 
+for style_symb in UCM.all_styles
+    com_str = "\\sym$(style_symb)"
+    command_definitions[com_str] = (TeXExpr(:sym, style_symb), 1)
+end
+
 ##
 ## Symbols
 ##


### PR DESCRIPTION
This is a follow-up to https://github.com/Kolaru/MathTeXEngine.jl/pull/141

I have factored out the UnicodeMath stuff into a new package. 
It is awaiting [registration](https://github.com/JuliaRegistries/General/pull/139139).

Right now, I have only added the `\symxx` commands, not the additional commands that `unicode-math` also defines. 

Still a WIP.