### PR TITLE
Reference image update

### DIFF
--- a/reference/Project.toml
+++ b/reference/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 MathTeXEngine = "0a4f8689-d25c-4efe-a92b-7142dfc1aa53"

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -38,6 +38,15 @@ function image_paths(references)
     return paths
 end
 
+function image_distance(img1, img2)
+    diffs = (
+        abs.(red.(img1) - red.(img2)) + 
+        abs.(green.(img1) - green.(img2)) + 
+        abs.(blue.(img1) - blue.(img2))
+    ) / 3
+    return maximum(diffs)
+end
+
 @testset "Reference images" begin
     @info "Reference test started"
 
@@ -63,7 +72,7 @@ end
         refimg = rotr90(load(joinpath(reference_images, image_path)))
         img = rotr90(load(joinpath(comparison_images, image_path)))
 
-        if img != refimg
+        if image_distance(img, refimg) > 0.1
             @info "Saving the reference comparison for '$image_path'."
             fig = Figure(size = (3*size(img, 1), size(img, 2)))
             Label(fig[1, 1], "Reference $(size(refimg))", tellwidth=false)

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -38,11 +38,8 @@ function image_paths(references)
     return paths
 end
 
-function image_distance(img1, img2)
-    return maximum(image_difference(img1, img2)) ./ 100
-end
-
-image_difference(img1, img2) = colordiff.(img1, img2)
+n_bad_pixels(img1, img2) = count(>(0.5), image_difference(img1, img2))
+image_difference(img1, img2) = colordiff.(img1, img2) ./ 100
 
 @testset "Reference images" begin
     @info "Reference test started"
@@ -69,8 +66,8 @@ image_difference(img1, img2) = colordiff.(img1, img2)
         refimg = rotr90(load(joinpath(reference_images, image_path)))
         img = rotr90(load(joinpath(comparison_images, image_path)))
 
-        if image_distance(img, refimg) > 0.1
-            @info "Saving the reference comparison for '$image_path' (image difference $(image_distance(img, refimg)))"
+        if (failed = n_bad_pixels(img, refimg) >= 10)
+            @info "Saving the reference comparison for '$image_path' (image difference $(n_bad_pixels(img, refimg)))"
             fig = Figure(size = (3*size(img, 1), size(img, 2)))
             Label(fig[1, 1], "Reference $(size(refimg))", tellwidth=false)
             axref = Axis(fig[2, 1], aspect = DataAspect())
@@ -83,10 +80,13 @@ image_difference(img1, img2) = colordiff.(img1, img2)
             image!(axcurrent, img)
 
             if size(img) == size(refimg)
-                Label(fig[1, 3], "Image difference (maximum difference $(float(image_distance(img, refimg))))", tellwidth=false)
+                Label(fig[1, 3], "Difference ($(n_bad_pixels(img, refimg)) bad pixels). Blue: reference. Orange: current.", tellwidth=false)
                 axdiff = Axis(fig[2, 3], aspect = DataAspect())
                 hidedecorations!(axdiff)
-                image!(axdiff, 1 .- image_difference(img, refimg))
+                diff = Gray.(img) - Gray.(refimg)
+                overlay = RGB.(Gray.(refimg), Gray.(img)./2 .+ Gray.(refimg)./2, Gray.(img))
+
+                image!(axdiff, overlay)
             end
 
             comparison_path = joinpath(path, image_path)
@@ -94,6 +94,6 @@ image_difference(img1, img2) = colordiff.(img1, img2)
             @info "Saving the reference plot at $comparison_path"
             save(comparison_path, fig)
         end
-        @test img == refimg
+        @test !failed
     end
 end

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -7,7 +7,7 @@ using TOML
 
 include("references.jl")
 
-function download_refimages(tag = "refimages-v3")
+function download_refimages(tag = "refimages-v2")
     url = "https://github.com/Kolaru/MathTeXEngine.jl/releases/download/$tag/reference_images.tar"
     images_tar = joinpath(@__DIR__, "reference_images.tar")
     images = joinpath(@__DIR__, "reference_images")

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -59,19 +59,39 @@ end
     for image_path in image_paths(REFERENCES)
         @info "Comparing $image_path"
 
-        refimg = load(joinpath(reference_images, image_path))
-        img = load(joinpath(comparison_images, image_path))
+        refimg = rotr90(load(joinpath(reference_images, image_path)))
+        img = rotr90(load(joinpath(comparison_images, image_path)))
 
         if img != refimg
             @info "Saving the reference comparison for '$image_path'."
-            fig = Figure()
-            fig[1, 1] = Label(fig, "Reference", tellwidth=false)
-            axref = fig[2, 1] = Axis(fig, aspect=DataAspect())
-            image!(axref, rotr90(refimg))
+            fig = Figure(size = (3*size(img, 1), size(img, 2)))
+            Label(fig[1, 1], "Reference $(size(refimg))", tellwidth=false)
+            axref = Axis(fig[2, 1], aspect=DataAspect())
+            hidedecorations!(axref)
+            image!(axref, refimg)
 
-            fig[1, 2] = Label(fig, "Current", tellwidth=false)
-            axcurrent = fig[2, 2] = Axis(fig, aspect=DataAspect())
-            image!(axcurrent, rotr90(img))
+            Label(fig[1, 2], "Current $(size(img))", tellwidth=false)
+            axcurrent = Axis(fig[2, 2], aspect=DataAspect())
+            hidedecorations!(axcurrent)
+            image!(axcurrent, img)
+
+            if size(img) == size(refimg)
+                overlayed = fill(colorant"white", size(img))
+                for i in axes(img, 1)
+                    for j in axes(img, 2)
+                        overlayed[i, j] = RGB(
+                            convert(Gray, img[i, j]),
+                            convert(Gray, refimg[i, j]),
+                            1.0
+                        )
+                    end
+                end
+
+                Label(fig[1, 3], "Overlayed (reference in teal, current in magenta)", tellwidth=false)
+                axoverlayed = Axis(fig[2, 3], aspect=DataAspect())
+                hidedecorations!(axoverlayed)
+                image!(axoverlayed, overlayed)
+            end
 
             comparison_path = joinpath(path, image_path)
             mkpath(dirname(comparison_path))

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -7,7 +7,7 @@ using TOML
 
 include("references.jl")
 
-function download_refimages(tag = "refimages-v2")
+function download_refimages(tag = "refimages-v3")
     url = "https://github.com/Kolaru/MathTeXEngine.jl/releases/download/$tag/reference_images.tar"
     images_tar = joinpath(@__DIR__, "reference_images.tar")
     images = joinpath(@__DIR__, "reference_images")
@@ -42,7 +42,7 @@ end
 
     @info "Downloading reference images"
     reference_images = download_refimages()
-    @inof "Reference images downloaded in $reference_images"
+    @info "Reference images downloaded in $reference_images"
     
     @info "Generating comparison images"
     comparison_images = joinpath(@__DIR__, "comparison_images")
@@ -73,7 +73,9 @@ end
             axcurrent = fig[2, 2] = Axis(fig, aspect=DataAspect())
             image!(axcurrent, rotr90(img))
 
-            save(joinpath(path, image_path), fig)
+            comparison_path = joinpath(path, image_path)
+            mkpath(dirname(comparison_path))
+            save(comparison_path, fig)
         end
         @test img == refimg
     end

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -7,7 +7,7 @@ using TOML
 
 include("references.jl")
 
-function download_refimages(tag = "refimages-v2")
+function download_refimages(tag = "refimages-v3")
     url = "https://github.com/Kolaru/MathTeXEngine.jl/releases/download/$tag/reference_images.tar"
     images_tar = joinpath(@__DIR__, "reference_images.tar")
     images = joinpath(@__DIR__, "reference_images")

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -1,4 +1,5 @@
 using CairoMakie
+using Colors
 using FileIO
 using MathTeXEngine
 using Tar

--- a/reference/compare.jl
+++ b/reference/compare.jl
@@ -39,13 +39,10 @@ function image_paths(references)
 end
 
 function image_distance(img1, img2)
-    diffs = (
-        abs.(red.(img1) - red.(img2)) + 
-        abs.(green.(img1) - green.(img2)) + 
-        abs.(blue.(img1) - blue.(img2))
-    ) / 3
-    return maximum(diffs)
+    return maximum(image_difference(img1, img2)) ./ 100
 end
+
+image_difference(img1, img2) = colordiff.(img1, img2)
 
 @testset "Reference images" begin
     @info "Reference test started"
@@ -73,38 +70,28 @@ end
         img = rotr90(load(joinpath(comparison_images, image_path)))
 
         if image_distance(img, refimg) > 0.1
-            @info "Saving the reference comparison for '$image_path'."
+            @info "Saving the reference comparison for '$image_path' (image difference $(image_distance(img, refimg)))"
             fig = Figure(size = (3*size(img, 1), size(img, 2)))
             Label(fig[1, 1], "Reference $(size(refimg))", tellwidth=false)
-            axref = Axis(fig[2, 1], aspect=DataAspect())
+            axref = Axis(fig[2, 1], aspect = DataAspect())
             hidedecorations!(axref)
             image!(axref, refimg)
 
             Label(fig[1, 2], "Current $(size(img))", tellwidth=false)
-            axcurrent = Axis(fig[2, 2], aspect=DataAspect())
+            axcurrent = Axis(fig[2, 2], aspect = DataAspect())
             hidedecorations!(axcurrent)
             image!(axcurrent, img)
 
             if size(img) == size(refimg)
-                overlayed = fill(colorant"white", size(img))
-                for i in axes(img, 1)
-                    for j in axes(img, 2)
-                        overlayed[i, j] = RGB(
-                            convert(Gray, img[i, j]),
-                            convert(Gray, refimg[i, j]),
-                            1.0
-                        )
-                    end
-                end
-
-                Label(fig[1, 3], "Overlayed (reference in teal, current in magenta)", tellwidth=false)
-                axoverlayed = Axis(fig[2, 3], aspect=DataAspect())
-                hidedecorations!(axoverlayed)
-                image!(axoverlayed, overlayed)
+                Label(fig[1, 3], "Image difference (maximum difference $(float(image_distance(img, refimg))))", tellwidth=false)
+                axdiff = Axis(fig[2, 3], aspect = DataAspect())
+                hidedecorations!(axdiff)
+                image!(axdiff, 1 .- image_difference(img, refimg))
             end
 
             comparison_path = joinpath(path, image_path)
             mkpath(dirname(comparison_path))
+            @info "Saving the reference plot at $comparison_path"
             save(comparison_path, fig)
         end
         @test img == refimg

--- a/reference/references.jl
+++ b/reference/references.jl
@@ -20,7 +20,7 @@ const SUPPORTED_FONTS = [
 ]
 
 function generate(destination_folder, references = REFERENCES, fonts = SUPPORTED_FONTS)
-    @info "Generating reference images in folder $destination_folder"
+    @info "Generating images in folder $destination_folder"
 
     path = mkpath(destination_folder)
     failures = Dict()


### PR DESCRIPTION
## Summary

- Updates the reference image test harness to look for a `refimages-v3` release asset.
- Fixes the `@inof` typo that currently stops `reference/compare.jl` before image comparison can run.
- Creates nested output directories before saving comparison artifacts, so failures for paths such as `basics/punctuation.png` and `spacing/...png` upload useful images.

## Explanation

The current `ReferenceTests` workflow fails before it can provide useful comparison artifacts. First, the script hits a typo in an added logging call. After that is fixed, nested reference image paths need their parent directories created before `save` writes comparison figures.

This PR keeps the existing release-asset model for reference images and changes the default reference tag from `refimages-v2` to `refimages-v3`. The refreshed archive is not committed because `*.tar` is ignored by the repository; it should be uploaded as the `reference_images.tar` asset for the new `refimages-v3` release.

Sorry for the extra follow-up here. This is only provided in case it might be useful; please ignore if not.

Refreshed archive candidate:

- File: `/private/tmp/MathTeXEngine-reference_images-refreshed.tar`
- SHA256: `faa877773479c148e600bf35de5573c4d87fbc4c2f80b0986af3a26c435b95c0`

## Tests

- `git diff --check`: passed.
- `julia --project=reference --startup-file=no -e 'Meta.parseall(read("reference/compare.jl", String)); println("parse ok")'`: passed.
- `REUSE_IMAGES_TAR=1 julia --project=reference --startup-file=no reference/compare.jl`: passed, 23/23 reference images.
- `julia --project=reference --startup-file=no reference/compare.jl` against the currently published `refimages-v2`: failed, 1 passed / 22 failed, but now writes comparison artifacts instead of crashing.
